### PR TITLE
register notification

### DIFF
--- a/ios/RNExactTarget.h
+++ b/ios/RNExactTarget.h
@@ -11,7 +11,18 @@
 #import <React/RCTEventEmitter.h>
 #endif
 
+/**
+ Please note that this is a singleton object, and you should reference it as [RNExactTarget pushManager].
+ */
+
 @interface RNExactTarget : RCTEventEmitter <RCTBridgeModule>
+/**
+ Returns (or initializes) the shared pushManager instance.
+ @return The singleton instance of an RNExactTarget pushManager.
+ */
++(nullable instancetype)pushManager;
+-(instancetype _Nonnull)init;
+
 - (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *_Nonnull)notificationSettings;
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *_Nonnull)deviceToken;
 - (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *_Nonnull)error;

--- a/ios/RNExactTarget.h
+++ b/ios/RNExactTarget.h
@@ -12,6 +12,11 @@
 #endif
 
 @interface RNExactTarget : RCTEventEmitter <RCTBridgeModule>
+- (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *_Nonnull)notificationSettings;
+- (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *_Nonnull)deviceToken;
+- (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *_Nonnull)error;
+- (void)handleRemoteNotification:(NSDictionary *_Nullable)userInfo;
+- (void)handleLocalNotification:(UILocalNotification *_Nullable)localNotification;
 
 @end
   

--- a/ios/RNExactTarget.m
+++ b/ios/RNExactTarget.m
@@ -2,6 +2,7 @@
 #import <React/RCTLog.h>
 #import "RNExactTarget.h"
 #import "ETPush.h"
+#import "ETAnalytics.h"
 
 @implementation RNExactTarget
 
@@ -108,6 +109,22 @@ RCT_EXPORT_METHOD(shouldDisplayAlertViewIfPushReceived:(BOOL *)enabled) {
     [[ETPush pushManager] shouldDisplayAlertViewIfPushReceived:enabled];
 }
 
+// Wrapper for ETPush method for post-registration delegate methods
+- (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
+    [[ETPush pushManager] didRegisterUserNotificationSettings:notificationSettings];
+}
+
+- (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    // register device token to SFMC
+    [[ETPush pushManager] registerDeviceToken:deviceToken];
+}
+
+- (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    [[ETPush pushManager] applicationDidFailToRegisterForRemoteNotificationsWithError:error];
+    [ETAnalytics trackPageView:@"data://applicationDidFailToRegisterForRemoteNotificationsWithError" andTitle:[error localizedDescription] andItem:nil andSearch:nil];
+}
+
+// Handlers for received notification
 - (void)handleRemoteNotification:(NSDictionary *_Nullable)userInfo {
     if (hasListeners) {
         [self sendEventWithName:@"ET:PUSH_NOTIFICATION_RECEIVED" body:userInfo];

--- a/ios/RNExactTarget.m
+++ b/ios/RNExactTarget.m
@@ -78,10 +78,12 @@ RCT_REMAP_METHOD(initializePushManager, initializePushManager:(NSDictionary *)et
             };
             
             // Start registration to APNS to get a device token
-            [[ETPush pushManager] registerForRemoteNotificationsWithDelegate:self
-                                                                     options:authOptions
-                                                                  categories:nil
-                                                           completionHandler:completionHandler];
+            dispatch_async(dispatch_get_main_queue(), ^(void) {
+                [[ETPush pushManager] registerForRemoteNotificationsWithDelegate:self
+                                                                         options:authOptions
+                                                                      categories:nil
+                                                               completionHandler:completionHandler];
+            }
         }
         else {
             UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:
@@ -90,8 +92,10 @@ RCT_REMAP_METHOD(initializePushManager, initializePushManager:(NSDictionary *)et
                                                     UIUserNotificationTypeAlert
                                                                                      categories:nil];
             // Notify the SDK what user notification settings have been selected
-            [[ETPush pushManager] registerUserNotificationSettings:settings];
-            [[ETPush pushManager] registerForRemoteNotifications];
+            dispatch_async(dispatch_get_main_queue(), ^(void) {
+                [[ETPush pushManager] registerUserNotificationSettings:settings];
+                [[ETPush pushManager] registerForRemoteNotifications];
+            }
         }
         
         resolve(@"successful");


### PR DESCRIPTION
## GIF
![Communication](https://im5.ezgif.com/tmp/ezgif-5-fa2821a723.gif)



## Overview
Hi, 


This PR suggests several fixes to make RNExactTarget works with notification registration.

First, let me bring a brief overview of how push notification registration works.

1. Initialize a connection to SFMC API - initialize pushManager with configureSDK with AppID and AccessToken inside of react view. 

2. Initialize connection to APNS in native delegate methods. (such as `didRegisterForRemoteNotificationsWithDeviceToken`)

3. A device token is given by the step 2 through APNS. Now, App needs to register the given device token to SFMC. 

So far, RNExactTarget implementation has covered the step 1 only. This PR is for covering the step 2 and 3. 


What this PR includes:

1. Call ETPush registerForRemoteNotifications so that it can get device token from APNS.

2. Exposed delegated methods
```
- (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *_Nonnull)notificationSettings;
- (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *_Nonnull)deviceToken;
- (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *_Nonnull)error;
- (void)handleRemoteNotification:(NSDictionary *_Nullable)userInfo;
- (void)handleLocalNotification:(UILocalNotification *_Nullable)localNotification;
```
The notification delegate methods need to sit in AppDelegate level in iOS. It's restriction of iOS. 
However, what those native delegate methods do is, just passing events to ETPush layer. 

Example is here
https://github.com/salesforce-marketingcloud/LearningAppIos/blob/210-v4.9.6/LearningAppIos/MarketingCloud/AppDelegate%2BETPush.m#L152-L191

or here
https://facebook.github.io/react-native/docs/pushnotificationios.html#content

A consumer of this library have to have those delegates in AppDelegate and need to pass events to ETPush.
However, ETPush is not directly imported into consumer app, so that it would look weird. 
Instead of calling ETPush directly, by exposing wrapper, the consumer can call RNExactTarget's methods. 


For example, 
it could be like this in consumer's AppDelegate
```
// AppDelegate.m
// Importing ETPush stuff in addition to RNExactTarget
#import "ETPush.h"
#import "ETAnalytics.h"
#import "RNExactTarget.h"
...
@implementation AppDelegate
...
- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
  [[ETPush pushManager] didRegisterUserNotificationSettings:notificationSettings];
}

- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
  [[ETPush pushManager] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
}

- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
  [[ETPush pushManager] didFailToRegisterForRemoteNotificationsWithError:error];
 }
```

Instead of the above, we suggest this
```
// AppDelegate.m
// Import only RNExactTarget
#import "RNExactTarget.h"
...
@implementation AppDelegate
...
// call RNExactTarget methods, instead of ETPush ones.
- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
  [[RNExactTarget pushManager] didRegisterUserNotificationSettings:notificationSettings];
}

- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
  [[RNExactTarget pushManager] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
}

- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
  [[RNExactTarget pushManager] didFailToRegisterForRemoteNotificationsWithError:error];
 }
```

3. Singleton 

To make RNExactTarget usable in delegate methods, I made it singleton 
which is the same pattern to what ETPush has, so that consumers can use it more intuitively.


## Testing Steps
Manual testing.

1. Imported current adjusted project into our real app
2. Implemented notification delegates in AppDelegate and called RNExactTarget's functions.
3. We could see device token is registered in our SFMC side successfully. 