### PR TITLE
feat: propagate jb4a init errors to client

### DIFF
--- a/ios/RNExactTarget.m
+++ b/ios/RNExactTarget.m
@@ -63,8 +63,8 @@ RCT_REMAP_METHOD(initializePushManager, initializePushManager:(NSDictionary *)et
                                                        error:&error];
     
     if (!successful) {
-        NSString *errorMessage = [NSString stringWithFormat: @"Could not initialize JB4A-SDK with appId %@ and accesstoken %@. Please check your configuration.", appId, accessToken];
-        reject(@"sdk_init_error", errorMessage, nil);
+        NSString *errorMessage = [NSString stringWithFormat: @"Could not initialize JB4A-SDK with appId %@ and accesstoken %@. Please check your configuration.\n%@", appId, accessToken, [error localizedDescription]];
+        reject(@"sdk_init_error", errorMessage, error);
     } else {
         /** Register for push notifications - enable all notification types, no categories */
         if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_x_Max) {


### PR DESCRIPTION
Propagate stacktrace down upon jb4-sdk initialization error.

<img width="391" alt="screen shot 2017-11-13 at 1 29 14 pm" src="https://user-images.githubusercontent.com/32276839/32747517-f2209e52-c886-11e7-9cc6-24c4a172a99b.png">
