### PR TITLE
fix: Forgot to implement singleton.

### DIFF
--- a/ios/RNExactTarget.h
+++ b/ios/RNExactTarget.h
@@ -20,8 +20,8 @@
  Returns (or initializes) the shared pushManager instance.
  @return The singleton instance of an RNExactTarget pushManager.
  */
-+(nullable instancetype)pushManager;
--(instancetype _Nonnull)init;
++ (instancetype _Nullable)pushManager;
+- (instancetype _Nonnull)init;
 
 - (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *_Nonnull)notificationSettings;
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *_Nonnull)deviceToken;
@@ -30,4 +30,3 @@
 - (void)handleLocalNotification:(UILocalNotification *_Nullable)localNotification;
 
 @end
-  

--- a/ios/RNExactTarget.m
+++ b/ios/RNExactTarget.m
@@ -5,6 +5,20 @@
 #import "ETAnalytics.h"
 
 @implementation RNExactTarget
++ (instancetype)pushManager {
+    static RNExactTarget *sharedPushManager = nil;
+    @synchronized(self) {
+        if (sharedPushManager == nil) {
+            sharedPushManager = [[self alloc] init];
+        }
+    }
+    return sharedPushManager;
+}
+
+- (instancetype)init {
+    self = [super init];
+    return self;
+}
 
 bool hasListeners;
 
@@ -19,13 +33,13 @@ bool hasListeners;
 }
 
 // Will be called when this module's first listener is added.
--(void)startObserving {
+- (void)startObserving {
     hasListeners = YES;
     // Set up any upstream listeners or background tasks as necessary
 }
 
 // Will be called when this module's last listener is removed, or on dealloc.
--(void)stopObserving {
+- (void)stopObserving {
     hasListeners = NO;
     // Remove upstream listeners, stop unnecessary background tasks
 }


### PR DESCRIPTION
Overview:
----
RNExactTarget has not been being worked ok as singleton init wasn't implemented. For example, when you run your app with initializePushManager, following method, `didFailToRegisterForRemoteNotificationsWithError` does not exist in RNExactTarget in delegate method of AppDelegate
```
- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
  // This does not exist, thus it will throw an exception. 
  [[RNExactTarget pushManager] didFailToRegisterForRemoteNotificationsWithError:error];
 }
```  
Maybe, we have tested with cached build so we could not catch this. 

I added the implementation and confirmed it worked ok.