### PR TITLE
fix: Prevent duplicate user notification register

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,21 @@ export default {
           });
       }
     );
+  },
 
+  registerForRemoteNotifications: () => {
+    return new Promise(
+      (resolve, reject) => {
+        RNExactTarget
+          .registerForRemoteNotifications()
+          .then(resolve)
+          .catch(reject)
+      }
+    );
+  },
+
+  setSubscriberKey: (key) => {
+    RNExactTarget.setSubscriberKey(key);
   },
 
   resetBadgeCount: () => {

--- a/ios/RNExactTarget.m
+++ b/ios/RNExactTarget.m
@@ -22,6 +22,8 @@
 
 bool hasListeners;
 
+bool isSdkInitialized = NO;
+
 - (NSArray<NSString *> *)supportedEvents
 {
     return @[@"ET:PUSH_NOTIFICATION_RECEIVED", @"ET:LOCAL_NOTIFICATION_RECEIVED"];
@@ -106,18 +108,25 @@ RCT_REMAP_METHOD(initializePushManager, initializePushManager:(NSDictionary *)et
 #endif
     
     // Initialize SDK with SFMC AppID and AccessToken
-    successful = [[ETPush pushManager] configureSDKWithAppID:appId
-                                              andAccessToken:accessToken
-                                               withAnalytics:withAnalytics
-                                         andLocationServices:andLocationServices
-                                        andProximityServices:andProximityServices
-                                               andCloudPages:andCloudPages
-                                             withPIAnalytics:withAnalytics
-                                                       error:&error];
-    
-    if (!successful) {
-        NSString *errorMessage = [NSString stringWithFormat: @"Could not initialize JB4A-SDK with appId %@ and accesstoken %@. Please check your configuration.\n%@", appId, accessToken, [error localizedDescription]];
-        reject(@"sdk_init_error", errorMessage, error);
+    if (!isSdkInitialized) {
+        successful = [[ETPush pushManager] configureSDKWithAppID:appId
+                                                  andAccessToken:accessToken
+                                                   withAnalytics:withAnalytics
+                                             andLocationServices:andLocationServices
+                                            andProximityServices:andProximityServices
+                                                   andCloudPages:andCloudPages
+                                                 withPIAnalytics:withAnalytics
+                                                           error:&error];
+        
+        if (!successful) {
+            NSString *errorMessage = [NSString stringWithFormat: @"Could not initialize JB4A-SDK with appId %@ and accesstoken %@. Please check your configuration.\n%@", appId, accessToken, [error localizedDescription]];
+            reject(@"sdk_init_error", errorMessage, error);
+        }
+        
+        isSdkInitialized = YES;
+        RCTLogInfo(@"Initializing ETPush succeeded.", appId, accessToken);
+    } else {
+        RCTLogInfo(@"ETPush has already been initialized.", appId, accessToken);
     }
     
     resolve(@"successful");

--- a/ios/RNExactTarget.m
+++ b/ios/RNExactTarget.m
@@ -123,6 +123,12 @@ RCT_REMAP_METHOD(initializePushManager, initializePushManager:(NSDictionary *)et
     resolve(@"successful");
 }
 
+RCT_EXPORT_METHOD(setSubscriberKey:(nonnull NSString*) key)
+{
+    RCTLogInfo(@"Setting subscriber key to SFMC: %s", key);
+    [[ETPush pushManager] setSubscriberKey:key];
+}
+
 RCT_EXPORT_METHOD(resetBadgeCount)
 {
     RCTLogInfo(@"Resetting badge count");


### PR DESCRIPTION
@daniel-deutsch-zocdoc 
@ericnograles 


![GiantRubberDuck](https://i.imgflip.com/203bzp.jpg)


Overview
----
Registering user notification to APNS and registering Device Token to SFMC should happen only once after application installation.
Don't get this wrong - initialization of SDK still should happen every app launches. 


1. Separated configureSDK for ETPush and registerForRemoteNotifications. These need to be called explicitly by the user. (It's a breaking change) 

2. registerForRemoteNotifications returns Promise. 

3. configureSDK will not be called if it has been already called. 

4. registerForRemoteNotifications will not be called if it has been already called. 

5. Added setSubscriberKey function exposed to react.