### PR TITLE
Docs/0.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ react-native-exact-target provides bridging functionality to Salesforce Marketin
 | 0.0.x+ | < 0.40 | 4.7.1 | 4.7.0.x | 
 | 0.1.3+ | > 0.40 and <= 0.46 | 4.7.1 | 4.7.0.x |
 | 0.2.0+ | >= 0.47 | 4.7.1 | 4.7.0.x |
+| 0.3.x | >= 0.47 | 4.7.1 | 4.7.0.x |
 
 **Note**: Please ignore v0.1.0 - v0.1.2. Incorrect semver was followed here and these releases are therefore deprecated.
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,34 @@ allprojects {
 
 Typically, you'll want to initialize ExactTarget on the `componentDidMount` of your App.js, like so:
 
+#### iOS
+
+```jsx
+import ExactTarget from 'react-native-exact-target';
+
+componentDidMount() {
+        ExactTarget
+          .initializePushManager({
+            appId: 'test-app-id-ios',
+            accessToken: 'test-access-token-ios',
+            enableAnalytics: false,
+            enableLocationServices: false,
+            enableProximityServices: false,
+            enableCloudPages: false,
+            enablePIAnalytics: false
+          })
+          .catch(error => {
+            console.log('There has been an error');
+            console.error(error);
+          });
+        
+        // This is to register the app on APNs, this bit isn't needed for GCM on Android
+        ExactTarget.registerForRemoteNotifications();
+}
+```
+
+#### Android
+
 ```jsx
 import ExactTarget from 'react-native-exact-target';
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,32 @@ allprojects {
 
 Typically, you'll want to initialize ExactTarget on the `componentDidMount` of your App.js, like so:
 
-#### iOS
+#### Versions Prior to 0.3.x
+
+```jsx
+import ExactTarget from 'react-native-exact-target';
+
+componentDidMount() {
+        ExactTarget
+          .initializePushManager({
+            appId: 'test-app-id-ios',
+            accessToken: 'test-access-token-ios',
+            enableAnalytics: false,
+            enableLocationServices: false,
+            enableProximityServices: false,
+            enableCloudPages: false,
+            enablePIAnalytics: false
+          })
+          .catch(error => {
+            console.log('There has been an error');
+            console.error(error);
+          });
+}
+```
+
+#### 0.3.x
+
+##### iOS
 
 ```jsx
 import ExactTarget from 'react-native-exact-target';
@@ -170,7 +195,7 @@ componentDidMount() {
 }
 ```
 
-#### Android
+##### Android
 
 ```jsx
 import ExactTarget from 'react-native-exact-target';

--- a/README.md
+++ b/README.md
@@ -167,12 +167,12 @@ componentDidMount() {
 }
 ```
 
-#### 0.3.x
-
-##### iOS
+#### 0.3.x and Future Releases
 
 ```jsx
+import { Platform } from 'react-native';
 import ExactTarget from 'react-native-exact-target';
+
 
 componentDidMount() {
         ExactTarget
@@ -191,30 +191,9 @@ componentDidMount() {
           });
         
         // This is to register the app on APNs, this bit isn't needed for GCM on Android
-        ExactTarget.registerForRemoteNotifications();
-}
-```
-
-##### Android
-
-```jsx
-import ExactTarget from 'react-native-exact-target';
-
-componentDidMount() {
-        ExactTarget
-          .initializePushManager({
-            appId: 'test-app-id-ios',
-            accessToken: 'test-access-token-ios',
-            enableAnalytics: false,
-            enableLocationServices: false,
-            enableProximityServices: false,
-            enableCloudPages: false,
-            enablePIAnalytics: false
-          })
-          .catch(error => {
-            console.log('There has been an error');
-            console.error(error);
-          });
+        if (Platform.OS === 'ios') {
+            ExactTarget.registerForRemoteNotifications();
+        }
 }
 ```
 


### PR DESCRIPTION
@jin-hwang-zocdoc can you review this doc update to the README.md and this block of code in Android and let me know if it looks good: https://github.com/ericnograles/react-native-exact-target/blob/docs/0.3.x/android/src/main/java/com/exacttarget/etpushsdk/reactnative/RNExactTargetModule.java#L90  

I basically mimicked the same thing as #12 for Android, except it appears that we don't need to imperatively register to GCM -- that process appears to be considerably simpler on Android.

Once I get your okay, I'll cut `0.3.0` to NPM. Thanks for your help with this!
